### PR TITLE
Filters added to modify the archive list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Change the year font colour:
 
 ## Changelog
 
+**1.1.1**
+* Added filters that allow developers to easily modify the archive list.
+
 **1.1.0**
 * Added a new option in the widget where you can choose to auto expand the current month or not.
 

--- a/expanding-archives.php
+++ b/expanding-archives.php
@@ -3,7 +3,7 @@
  * Plugin Name: Expanding Archives
  * Plugin URI: https://shop.nosegraze.com/product/expanding-archives/
  * Description: A widget showing old posts that you can expand by year and month.
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Nose Graze
  * Author URI: https://www.nosegraze.com
  * License: GPL2
@@ -11,7 +11,7 @@
  * Domain Path: lang
  *
  * @package   expanding-archives
- * @copyright Copyright (c) 2015, Ashley Evans
+ * @copyright Copyright (c) 2019, Ashley Evans
  * @license   GPL2+
  *
  * This program is free software; you can redistribute it and/or modify
@@ -40,7 +40,7 @@ include_once plugin_dir_path( __FILE__ ) . 'inc/class-expanding-archives.php';
  * @return NG_Expanding_Archives
  */
 function NG_Expanding_Archives() {
-	$instance = NG_Expanding_Archives::instance( __FILE__, '1.1.0' );
+	$instance = NG_Expanding_Archives::instance( __FILE__, '1.1.1' );
 
 	return $instance;
 }

--- a/inc/class-expanding-archives.php
+++ b/inc/class-expanding-archives.php
@@ -226,13 +226,16 @@ class NG_Expanding_Archives {
 			$year  = date( 'Y' );
 			$month = date( 'm' );
 
-			// Query the posts.
-			$archives = get_posts( array(
+			$arc_args = array(
 				'posts_per_page' => - 1,
 				'nopaging'       => true,
 				'year'           => intval( $year ),
 				'monthnum'       => intval( $month ),
-			) );
+			);
+			$arc_args = apply_filters( 'expanding_archives_get_posts', $arc_args );
+
+			// Query the posts.
+			$archives = get_posts( $arc_args );
 
 			// If we have results, add each one to a list.
 			if ( $archives ) {
@@ -268,14 +271,17 @@ class NG_Expanding_Archives {
 		$month = strip_tags( $_POST['month'] );
 		$year  = strip_tags( $_POST['year'] );
 
-		// Query for posts in the given month/year.
-		$archives = get_posts( array(
+		$arc_args = array(
 			'posts_per_page' => - 1,
 			'nopaging'       => true,
 			'year'           => intval( $year ),
 			'monthnum'       => intval( $month ),
-		) );
+		);
+		$arc_args = apply_filters( 'expanding_archives_list_posts', $arc_args );
 
+		// Query for posts in the given month/year.
+		$archives = get_posts( $arc_args );
+		
 		// If we have results, add each one to our list.
 		if ( $archives ) {
 			$result = '<ul>';
@@ -283,11 +289,10 @@ class NG_Expanding_Archives {
 				$result .= '<li><a href="' . get_permalink( $archive ) . '">' . get_the_title( $archive ) . '</a></li>';
 			}
 			$result .= '</ul>';
-			wp_send_json_success( $result );
 		} else {
 			$result = '<ul><li>' . __( 'No posts found.', $this->_token ) . '</li></ul>';
-			wp_send_json_success( $result );
 		}
+		wp_send_json_success( $result );
 
 		exit;
 	}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -17,7 +17,9 @@ function expanding_archives_get_months() {
 	global $wpdb;
 
 	if ( false === ( $months = get_transient( 'expanding_archives_months' ) ) ) {
-		$months = $wpdb->get_results( "SELECT DISTINCT MONTH( post_date ) AS month , YEAR( post_date ) AS year, COUNT( id ) as post_count FROM $wpdb->posts WHERE post_status = 'publish' and post_date <= now( ) and post_type = 'post' GROUP BY month , year ORDER BY post_date DESC" );
+		$query = "SELECT DISTINCT MONTH( post_date ) AS month , YEAR( post_date ) AS year, COUNT( id ) as post_count FROM $wpdb->posts WHERE post_status = 'publish' and post_date <= now( ) and post_type = 'post' GROUP BY month , year ORDER BY post_date DESC";
+		$query = apply_filters( 'expanding_archives_query', $query );
+		$months = $wpdb->get_results( $query );
 
 		set_transient( 'expanding_archives_months', $months, DAY_IN_SECONDS );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: NoseGraze
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=L2TL7ZBVUMG9C
 Tags: widget, sidebar, posts, archives, navigation, menu, collapse, expand, collapsing, collapsible, expanding, expandable
 Requires at least: 3.0
-Tested up to: 4.9
+Tested up to: 5.0.3
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -52,6 +52,9 @@ Change the year font colour:
 
 == Changelog ==
 
+= 1.1.1 =
+* Added filters that allow developers to easily modify the archive list.
+
 = 1.1.0 =
 * Added a new option in the widget where you can choose to auto expand the current month or not.
 
@@ -76,5 +79,5 @@ Change the year font colour:
 
 == Upgrade Notice ==
 
-= 1.1.0 =
-New option in the widget to disable automatically expanding the current month.
+= 1.1.1 =
+* Added filters that allow developers to easily modify the archive list.


### PR DESCRIPTION
Added filters to modify the archive list. This allows for things like:
```
//Omit Category/Taxonomy ie: newsletter (category ID: 51)
add_filter( 'expanding_archives_get_posts', 'omit_newsletter', 10, 1 );
add_filter( 'expanding_archives_list_posts', 'omit_newsletter', 10, 1 );
function omit_newsletter($arc_args){
	$arc_args['tax_query'] = array(
		array(
			'taxonomy' => 'category',
			'terms' => array('newsletter'),
			'field' => 'slug',
			'operator'  => 'NOT IN'
		)
	);
	return $arc_args;
}

add_filter( 'expanding_archives_query', 'omit_newsletter_query', 10, 1 );
function omit_newsletter_query($query){
	global $wpdb;
	$query = "SELECT 
		DISTINCT MONTH( post_date ) AS month, 
		YEAR( post_date ) AS year, 
		COUNT( ID ) as post_count 
		FROM $wpdb->posts 
		WHERE post_status = 'publish' and post_date <= now( ) and post_type = 'post'
		AND ( $wpdb->posts.ID NOT IN ( SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id IN (51) ) )
		GROUP BY month , year 
		ORDER BY post_date DESC";
	return $query;
}
```
Can also be used to show only a single category as requested in [this support issue](https://wordpress.org/support/topic/specify-category/)

```
//Include Single Category/Taxonomy ie: newsletter (category ID: 51)
add_filter( 'expanding_archives_get_posts', 'only_newsletter', 10, 1 );
add_filter( 'expanding_archives_list_posts', 'only_newsletter', 10, 1 );
function only_newsletter($arc_args){
	$arc_args['tax_query'] = array(
		array(
			'taxonomy' => 'category',
			'terms' => array('newsletter'),
			'field' => 'slug',
		)
	);
	return $arc_args;
}

add_filter( 'expanding_archives_query', 'only_newsletter_query', 10, 1 );
function only_newsletter_query($query){
	global $wpdb;
	$query = "SELECT 
		DISTINCT MONTH( post_date ) AS month, 
		YEAR( post_date ) AS year, 
		COUNT( ID ) as post_count 
		FROM $wpdb->posts 
		LEFT JOIN $wpdb->term_relationships ON ($wpdb->posts.id = $wpdb->term_relationships.object_id)
		LEFT JOIN $wpdb->term_taxonomy ON ($wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id)
		WHERE post_status = 'publish' and post_date <= now( ) and post_type = 'post'
		AND $wpdb->term_taxonomy.taxonomy = 'category'
		AND $wpdb->term_taxonomy.term_id =51
		GROUP BY month , year 
		ORDER BY post_date DESC";
	return $query;
}
```